### PR TITLE
update instructions for Akamai Terraform resources

### DIFF
--- a/pages/exercises/5-ex-resources.mdx
+++ b/pages/exercises/5-ex-resources.mdx
@@ -1,7 +1,8 @@
-import { Steps } from 'nextra/components'
-import { Callout } from 'nextra/components'
+import { Steps } from "nextra/components";
+import { Callout } from "nextra/components";
 
 ### Exercise \#1
+
 <Steps>
 {<h3>New File</h3>}
 Create a terraform file named **_security.tf_** with an `akamai_appsec_configuration` resource and an `akamai_appsec_security_policy` resource
@@ -13,7 +14,7 @@ Configure the `akamai_appsec_security_policy` resource to get its `config_id` fr
 Run a `terraform apply`
 
 {<h3>Reconfigure</h3>}
-Duplicate the policy resouce and make the necessary modifications to create a new policy. 
+Duplicate the policy resouce and make the necessary modifications to create a new policy.
 
 {<h3>Apply</h3>}
 Run another `terraform apply`
@@ -22,24 +23,28 @@ Run another `terraform apply`
 Run a `terraform destroy`. What happens?
 
 {<h3>Re-Apply</h3>}
-Re-apply your terraform code to recreate your resources as we may need them later on. 
+Re-apply your terraform code to recreate your resources as we may need them later on.
 
 {<h3>Commit</h3>}
-Commit your changes and push them to GitHub. 
+Commit your changes and push them to GitHub.
+
 </Steps>
 
 ### Exercise \#2
+
 <Steps>
 {<h3>New File</h3>}
 Create a terraform file named **_property.tf_** with the following resources:
-  - CP Code: use the resource `akamai_cp_code` to create a new CP code
-  - Edge Hostname: use the resources `akamai_property` resource, cp_code and edge_hostname
-  - Property: use the resources `akamai_property` resource, cp_code and edge_hostname
+  - CP Code: use the resource `akamai_cp_code` to create a new CP code with the `name`, `contract_id`, `group_id`, `product_id` arguements
+  - Edge Hostname: use the resource `akamai_edge_hostname` to create a new CP code with the `contract_id`, `group_id`, `product_id`, `ip_behavior` and `edge_hostname` arguements
+  - Property: use the resources `akamai_property` resource, cp_code and edge_hostname with the `name`, `contract_id`, `group_id`, `product_id` arguements
 
 {<h3>Configure</h3>}
-Observe you'll need to configure a tree for the `akamai_property` too. 
+Observe you'll need to configure `hostnames`, `rules` and `rule_format` for the `akamai_property` too.
+
 <Callout type="info" emoji="ℹ️">
-_Hint_: check the `data.akamai_property_rules_builder` data source in Techdocs.
+  _Hint_: check the `data.akamai_property_rules_builder` data source in
+  Techdocs.
 </Callout>
 
 {<h3>Apply</h3>}
@@ -47,4 +52,5 @@ Run another `terraform apply`
 
 {<h3>Commit</h3>}
 Commit your changes and push them to GitHub.
+
 </Steps>


### PR DESCRIPTION
This PR updates the documentation to provide a clearer, more detailed set of instructions for configuring Akamai Terraform resources. 

Changes:
- Introduce a structured format for creating `property.tf`.
- Clarify required arguments (`name`, `contract_id`, `group_id`, `product_id`, `ip_behavior`, `edge_hostname`).